### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 NASA: Prospect
 ========
 
-####Website
+#### Website
 [Play It!](http://nasaprospect.com/ "NASA: Prospect")
 
-####Overview
+#### Overview
 Prospect is the interactive story of the planet prospectors, left behind by NASA to recover the golden objects of humankind scattered across the solar-system by a global disaster.  
 
-####Core Goal
+#### Core Goal
 The core goal of this project is to increase interest in space exploration.
 
-##Contributors
+## Contributors
 
-####Design and Development
+#### Design and Development
 
 Amanda Connelly  
 Amy Gehling  
@@ -20,20 +20,20 @@ Calvin LaBrie
 Ashley Palmer  
 Keaton Solomon
 
-####Advanced Coding Assistance
+#### Advanced Coding Assistance
 [Collin Hover](http://collinhover.com "Collin Hover")  
 
-####Music
+#### Music
   
 Misc Artists from [Jamendo](http://jamendo.com/)
   
-##Technology
+## Technology
   
 HTML5  
 CSS3  
 Javascript  
 
-####Libraries
+#### Libraries
  
 Modernizr  
 LESS  


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
